### PR TITLE
refactor: remove html base element

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="utf-8">
     <title>King for Kong</title>
-    <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="assets/img/favicon-96x96.png">


### PR DESCRIPTION
Resolve the problem of wrong location of resources.
For example, my gateway domain name is example.com, and then I configure the `/king/` route to point to king.
Next, when I visit `example.com/king/`, I will find that some URL not found, because their URL will be `example.com/styles.xxx.css` instead of `example.com/king/styles.xxx.css`.