### PR TITLE
Fixed add new plugin template error

### DIFF
--- a/src/app/components/dialog-new-plugin/dialog-new-plugin.component.ts
+++ b/src/app/components/dialog-new-plugin/dialog-new-plugin.component.ts
@@ -108,7 +108,7 @@ export class DialogNewPluginComponent implements OnInit, OnDestroy {
             this.api.getAllRoutes(null, [], ['id', 'name']),
             this.api.getAllConsumers(null, [], ['id', 'username']),
             this.api.getPluginsEnabled(),
-            this.api.getAllPlugins(null, [], ['id', 'name'])
+            this.api.getAllPlugins(null, [], [])
         ]).pipe(map<any, any>(([services, routes, consumers, pluginsEnabled, plugins]) => {
             // forkJoin returns an array of values, here we map those values to an object
             return {


### PR DESCRIPTION
Removed id and name specific fields from the api call so it retrieves all the information of the plugin and fill the template accordingly